### PR TITLE
Improve SPDX license normalization

### DIFF
--- a/tests/test_license_normalization.py
+++ b/tests/test_license_normalization.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pathlib
+
+# Ensure src is on the path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from hf2spdx_ai_bom import normalize_spdx_license
+
+
+def test_normalizes_common_variants():
+    assert normalize_spdx_license('Apache 2.0') == 'Apache-2.0'
+    assert normalize_spdx_license('Apache License 2.0') == 'Apache-2.0'
+    assert normalize_spdx_license('MIT License') == 'MIT'
+    assert normalize_spdx_license('gpl-3.0') == 'GPL-3.0-only'
+    assert normalize_spdx_license('unknown') is None


### PR DESCRIPTION
## Summary
- normalize license strings containing spaces, underscores or a trailing "License" suffix to canonical SPDX identifiers
- add tests covering common license name variants

## Testing
- `pytest -q` *(fails: fixture 'url' not found in scripts/auto_test.py)*
- `PYTHONPATH=src pytest tests/test_license_normalization.py -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689c040c0f8c83278ddc895f21e35dfe